### PR TITLE
New feature : select compendium

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -32,11 +32,13 @@
     "tblc.author": "Author",
     "tblc.submitTitle": "Data submit confirmation",
     "tblc.understandAndSubmit": "I understand (submit the data)",
+    "tblc.changeCompendium": "Choose another compendium",
     "tblc.noReviewer": "There is unfortunately no reviewer for that compendium. Contributions cannot be submitted for compendiums without a person in charge of reviewing them. Please see above documentation for more details.",
-
     
     "tblc.noInitiative": "No initiative",
     "tblc.noInitiativeDescription": "If you submit without specifying an initiative, your contribution could be rejected!",
+
+    "tblc.chooseCompendiumTitle": "Choose a compendium",
     
     "tblc.author": "Author",
     "tblc.authorPlaceHolder": "e.g Discord identifier",
@@ -67,6 +69,8 @@
     "tblc.deleteTitle": "Delete contribution",
     "tblc.deleteContent": "Are you sure you want to delete <i>{name}</i>? Data will be lost!",
     
+    "tblc.validate": "Validate",
+
     "SETTINGS.tblcLogin": "(Let's contribute) Screenname",
     "SETTINGS.tblcLoginHint": "If you are a reviewer, specify the screenname used for authentication on Let's contribute server (See project documentation for more information).",
     "SETTINGS.tblcAccessKey": "(Let's contribute) Access key",

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -32,10 +32,13 @@
     "tblc.author": "Auteur",
     "tblc.submitTitle": "Confirmation d'envoi de données",
     "tblc.understandAndSubmit": "Je comprends (envoyer les données)",
+    "tblc.changeCompendium": "Choisir un autre compendium",
     "tblc.noReviewer": "Il n'y a malheureusement aucun réviseur pour ce compendium. Aucune contribution ne peut être soumise pour un compendium pour lequel personne est en charge de la révision. Consultez la documentation ci-dessus pour plus de détails.",
     
     "tblc.noInitiative": "Aucune initiative",
     "tblc.noInitiativeDescription": "Si vous soumettez une contribution sans spécifier une initiative, celle-ci pourrait être rejetée!",
+    
+    "tblc.chooseCompendiumTitle": "Choisir un compendium",
     
     "tblc.author": "Auteur",
     "tblc.authorPlaceHolder": "ex identifiant Discord",
@@ -66,6 +69,8 @@
     "tblc.deleteTitle": "Supprimer la contribution",
     "tblc.deleteContent": "Êtes-vous sûr(e) de vouloir supprimer <i>{name}</i>? Les données seront perdues!",
     
+    "tblc.validate": "Valider",
+
     "SETTINGS.tblcLogin": "(Let's contribute) Nom d'utilisateur",
     "SETTINGS.tblcLoginHint": "Si vous êtes réviseur, veuillez spécifier le 'login' utilisé pour s'authentifier sur le serveur Let's contribute (Voir documentation du projet pour plus d'information).",
     "SETTINGS.tblcAccessKey": "(Let's contribute) Clé d'accès",

--- a/templates/letscontribute/choose-compendium.html
+++ b/templates/letscontribute/choose-compendium.html
@@ -1,0 +1,18 @@
+<form>
+  <div class="form-group">
+    <label>
+    <select name="selCompendium" class="compendium">
+      {{#select selCompendium}}
+      {{#each compendiums}}
+      <option value="{{this.key}}">{{this.label}} ({{this.key}})</option>
+      {{/each}}
+      {{/select}}
+    </select>
+    </label>
+  </div>
+  <div class="form-group">
+    <button class="dialog-button" data-button="submit">
+      <i class="fas fa-check"></i>{{localize "tblc.validate"}}
+    </button>
+  </div>
+</form>

--- a/templates/letscontribute/submit.html
+++ b/templates/letscontribute/submit.html
@@ -9,7 +9,13 @@
   </div>
   <div class="form-group">
     <label><b>{{localize "tblc.compendium"}}</b></label>
-    <label>{{compendium.metadata.label}} <em>({{compendium.collection}})</em></label>
+    <label>
+      {{compendium.metadata.label}} <em>({{compendium.collection}})</em> 
+      <br/>
+      <a class="changeCompendium description">
+        {{localize "tblc.changeCompendium"}}
+      </a>
+    </label>
   </div>
   <div class="form-group">
     <label><b>{{localize "tblc.system"}}</b></label>


### PR DESCRIPTION
Ajout d'une feature pour permettre de sélectionner un compendium

**Use case :** 

Un utilisateur souhaite envoyer des modifications d'une entrée de compendium.
L'utilisateur clique sur l'icone pour envoyer les modifications.
L'application choisit le premier compendium où il trouve l'entité, mais il ne s'agit pas du bon compendium d'origine de l'entrée.

**Description des modifications :** 

Ajout d'un texte "Choisir un autre compendium" sous le label du compendium sélectionné
![image](https://user-images.githubusercontent.com/11445580/103417598-93f86900-4b8b-11eb-9d8f-83b3d660651d.png)

Au clic sur "Choisir un autre compendium", ferme la modale de résumé et ouvre une modale permettant de sélectionner un compendium parmi tous les compendiums trouvés dans le monde de jeu triés par ordre alphabétique (accentutation locale prise en compte). Chaque compendium est représenté comme suit : "Nom du compendium (clé technique)"
![image](https://user-images.githubusercontent.com/11445580/103417608-9fe42b00-4b8b-11eb-9fbc-e7a7442d8f11.png)
![image](https://user-images.githubusercontent.com/11445580/103417619-ab375680-4b8b-11eb-9ef8-0e66653922f0.png)

Au clic sur "Valider", vérifie si il existe une entité de même nom que l'entité qu'on cherche à mettre à jour dans le compendium sélectionné. Si non, affiche un message d'erreur comme à l'accoutumée. Si oui, rouvre la modale de validation des informations avec le bon compendium sélectionné.
![image](https://user-images.githubusercontent.com/11445580/103417688-023d2b80-4b8c-11eb-9a65-9233c1434d40.png)
